### PR TITLE
Fix infinite loop at loop.cbl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,1 @@
-/OpenCobol/Sort/bin/
-/OpenCobol/SQLite/Hello_SQLITE
-
-/bin
-
-*.c
-*.h
-*.so
-*.o
-*.
+**/bin

--- a/OpenCobol/Loops/loop.cbl
+++ b/OpenCobol/Loops/loop.cbl
@@ -10,23 +10,28 @@
        INPUT-OUTPUT SECTION.
 
        FILE-CONTROL.
-           SELECT DATA-FILE ASSIGN TO 'database.dat'
+           SELECT DATA-FILE ASSIGN TO "../database.dat"
            ORGANIZATION IS SEQUENTIAL
-           ACCESS IS RANDOM
+           ACCESS IS SEQUENTIAL
            FILE STATUS FILE-STATUS.
 
        DATA DIVISION.
        FILE SECTION.
            FD DATA-FILE.
-
            01 DETAILS.
-              02 DETAILS-ID PIC 9(10).
+              02 DETAILS-ID PIC 9(7).
               02 DETAILS-NAME.
                  03 DETAILS-SURNAME PIC X(8).
                  03 INITIALS        PIC XX.
+              02 DETAILS-BIRTHDAY   PIC X(8).
+              02 SOME-CODE          PIC X(5).
+
 
        WORKING-STORAGE SECTION.
            77 FILE-STATUS PIC XX.
+           77 EOF PIC X.
+             88 EOF-T value "Y".
+             88 EOF-F value "N".
 
 
 
@@ -34,25 +39,40 @@
        MAIN-PROCEDURE.
            OPEN INPUT DATA-FILE.
 
+           IF FILE-STATUS not = "00"
+               DISPLAY "Error opening the DB file, program will exit."
+               GOBACK
+           END-IF.
+
+
            READ DATA-FILE
-               AT END MOVE HIGH-VALUES TO DETAILS
-      *         DISPLAY DETAILS
+               AT END
+                 SET EOF-T TO TRUE
+               NOT AT END
+                 SET EOF-F TO TRUE
+                 PERFORM DISPLAY-DET-S THROUGH DISPLAY-DET-E
            END-READ
 
-           PERFORM UNTIL DETAILS = HIGH-VALUES
-               DISPLAY DETAILS-ID SPACE DETAILS-NAME
-
-               READ DATA-FILE
-                   AT END MOVE HIGH-VALUES TO DETAILS
+           PERFORM UNTIL EOF-T
+               READ DATA-FILE NEXT
+                   AT END
+                     SET EOF-T TO TRUE
+                   NOT AT END
+      *               DISPLAY FILE-STATUS
+                     PERFORM DISPLAY-DET-S THROUGH DISPLAY-DET-E
                END-READ
-
-      *         DISPLAY "DETAILS-ID: " DETAILS-ID
-      *         DISPLAY "DETAILS-NAME: " DETAILS-NAME
-
            END-PERFORM
 
            CLOSE DATA-FILE.
-           STOP RUN.
-      *      DISPLAY "Hello world".
+           GOBACK.
+
+           DISPAY-DET SECTION.
+           DISPLAY-DET-S.
+               DISPLAY DETAILS.
+               DISPLAY "DETAILS-ID: " DETAILS-ID
+               DISPLAY "DETAILS-NAME: " DETAILS-SURNAME.
+               DISPLAY "DETAILS-BIRTHDAY: " DETAILS-BIRTHDAY.
+           DISPLAY-DET-E.
+               EXIT.
 
        END PROGRAM LOOP.


### PR DESCRIPTION
Fixes an infinite loop in loop.cbl.
 - READ NEXT was missing, also file definition was incorrect.
 - Changed path to the database file, as OpenCobol looks for the file in the same directory as the executable is running.
 - Shortened the database to 50 records as the original length always broke the OpenCobolIDE.

Fixes #3 