### PR TITLE
fix core_random_values.cbl / call DrawText

### DIFF
--- a/OpenCobol/Games/raylib/core_random_values.cbl
+++ b/OpenCobol/Games/raylib/core_random_values.cbl
@@ -2,7 +2,7 @@
       * Author: Maxfx
       * Date: 8/7/2018
       * Example: Cobol simple gui binding with raylib
-      * Compile with param: cobc -xj core_basic_window.cbl -lraylib
+      * Compile with param: cobc -xjd core_basic_window.cbl -lraylib
       ******************************************************************
       * OMITTED call void C <function>
       ******************************************************************

--- a/OpenCobol/Games/raylib/core_random_values.cbl
+++ b/OpenCobol/Games/raylib/core_random_values.cbl
@@ -33,7 +33,9 @@
       * Frame counter
        01 FRAME-COUNTER PIC 999 VALUE 0.
        01 RAN-NUM USAGE BINARY-LONG.
+       01 RAN-TXT PIC X(9).
        01 RESULT PIC 999 VALUE 0.
+
 
       * Structs for Colors rgba
        01 W-COLOR-WHITE.
@@ -113,10 +115,10 @@
            RETURNING OMITTED
           END-CALL
 
+           MOVE RAN-NUM to RAN-TXT
           CALL STATIC "DrawText" USING
-      * FIXME: This a part is ungly (RAN-NUM)
-           BY VALUE RAN-NUM
-           BY VALUE 360 180
+           BY REFERENCE RAN-TXT(9:1)
+           BY VALUE 360 220
            BY VALUE 80
            BY CONTENT W-COLOR-LIGHTGRAY
            RETURNING OMITTED


### PR DESCRIPTION
Hello Max, i have some fixes.
1.) fix DrawText calling 
2.) fix compilation params, -d cause showing errors from linked parts  