### PR TITLE
Fixed OpenCobol warnings

### DIFF
--- a/OpenCobol/Games/raylib/core_basic_window.cbl
+++ b/OpenCobol/Games/raylib/core_basic_window.cbl
@@ -55,8 +55,10 @@
          CALL "InitWindow" USING
           BY VALUE SRC-WIDTH SRC-HEIGHT
           BY REFERENCE W-NAME RETURNING R-CODE
-            ON EXCEPTION DISPLAY "exception error: raylib not found"
+            ON EXCEPTION
+            DISPLAY "exception error: raylib not found"
             UPON SYSERR
+            END-DISPLAY
          END-CALL
 
          CALL "SetTargetFPS" USING BY VALUE 60

--- a/OpenCobol/Games/raylib/core_random_values.cbl
+++ b/OpenCobol/Games/raylib/core_random_values.cbl
@@ -64,6 +64,7 @@
           BY REFERENCE W-NAME RETURNING R-CODE
             ON EXCEPTION DISPLAY "exception error: raylib not found"
             UPON SYSERR
+            END-DISPLAY
          END-CALL
 
          CALL "GetRandomValue" USING
@@ -84,7 +85,11 @@
           END-CALL
 
           ADD 1 TO FRAME-COUNTER
-          COMPUTE RESULT = FUNCTION MOD((FRAME-COUNTER / 120), 2)
+          END-ADD
+
+          COMPUTE
+            RESULT = FUNCTION MOD((FRAME-COUNTER / 120), 2)
+          END-COMPUTE
 
           IF RESULT = 1
             CALL "GetRandomValue" USING


### PR DESCRIPTION
Examples with raylib have some warings 
with compiler flags cobc -x -lraylib  -Wall -W
```
warning: DISPLAY statement not terminated by END-DISPLAY
warning: ADD statement not terminated by END-ADD
warning: COMPUTE statement not terminated by END-COMPUTE
```